### PR TITLE
Add command-line interface for chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This repository contains a minimal astrological chatbot that generates a random 
    uvicorn app:app --reload
    ```
 
+4. Use the command line interface to generate personalities or chat directly:
+   ```bash
+   python cli.py generate   # prints a personality profile
+   python cli.py chat       # start a terminal chat session
+   ```
+
 ## Development
 
 - Create a virtual environment and install dependencies from `requirements.txt`.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,43 @@
+import argparse
+from typing import Optional
+
+from app import AstroPersonalityBot
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Command line interface for the Astrological Personality Bot"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser(
+        "generate", help="Generate a new personality profile and exit"
+    )
+    subparsers.add_parser(
+        "chat", help="Generate a personality and start a chat session"
+    )
+
+    args = parser.parse_args(argv)
+
+    bot = AstroPersonalityBot()
+
+    if args.command == "generate":
+        display, _json, _data = bot.generate_new_personality()
+        print(display)
+    elif args.command == "chat":
+        display, _json, _data = bot.generate_new_personality()
+        print(display)
+        print("\nStart chatting with the generated personality. Type 'exit' to quit.\n")
+        while True:
+            try:
+                user_input = input("You: ")
+            except (EOFError, KeyboardInterrupt):
+                break
+            if user_input.strip().lower() in {"exit", "quit"}:
+                break
+            response = bot.chat(user_input)
+            print(f"Bot: {response}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- introduce `cli.py` with `main()` for generating personalities and chatting
- document new CLI usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8add60c08331a4f43badb894b96e