### PR TITLE
Handle missing language model gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,6 +242,10 @@ class AstroPersonalityBot:
         return system_prompt
 
     def generate_new_personality(self) -> Tuple[str, str, Dict[str, Any]]:
+        if self.tokenizer is None or self.model is None:
+            raise RuntimeError(
+                "Language model not loaded. Install required packages and re-run."
+            )
         birth_data = self.generate_random_birth_data()
         self.current_chart_json = self.generate_chart_json(birth_data)
         chart_data = json.loads(self.current_chart_json)
@@ -269,6 +273,10 @@ class AstroPersonalityBot:
     def chat(self, message: str) -> str:
         if not self.current_personality:
             return "Please generate a personality first by clicking the button above!"
+        if self.tokenizer is None or self.model is None:
+            raise RuntimeError(
+                "Language model not loaded. Install required packages and re-run."
+            )
         chat_prompt = (
             f"<s>[INST] <<SYS>>\n{self.current_personality['system_prompt']}\n<</SYS>>\n\n{message} [/INST]"
         )

--- a/cli.py
+++ b/cli.py
@@ -22,10 +22,18 @@ def main(argv: Optional[list[str]] = None) -> None:
     bot = AstroPersonalityBot()
 
     if args.command == "generate":
-        display, _json, _data = bot.generate_new_personality()
+        try:
+            display, _json, _data = bot.generate_new_personality()
+        except RuntimeError as exc:
+            print(exc)
+            return
         print(display)
     elif args.command == "chat":
-        display, _json, _data = bot.generate_new_personality()
+        try:
+            display, _json, _data = bot.generate_new_personality()
+        except RuntimeError as exc:
+            print(exc)
+            return
         print(display)
         print("\nStart chatting with the generated personality. Type 'exit' to quit.\n")
         while True:
@@ -35,7 +43,11 @@ def main(argv: Optional[list[str]] = None) -> None:
                 break
             if user_input.strip().lower() in {"exit", "quit"}:
                 break
-            response = bot.chat(user_input)
+            try:
+                response = bot.chat(user_input)
+            except RuntimeError as exc:
+                print(exc)
+                break
             print(f"Bot: {response}")
 
 


### PR DESCRIPTION
## Summary
- validate model and tokenizer in `AstroPersonalityBot`
- catch `RuntimeError` in CLI to print a friendly message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8f2056188331ab842457e833e4e1